### PR TITLE
fix: add start script for Railway deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"version": "0.0.1",
 	"type": "module",
 	"scripts": {
+		"start": "node build",
 		"dev": "doppler run -- vite dev",
 		"build": "vite build",
 		"preview": "vite preview",


### PR DESCRIPTION
## Summary

Railway requires a `start` script in `package.json` to know how to run the SvelteKit app after building.

## Changes

- Add `"start": "node build"` to package.json scripts

The `adapter-node` outputs a Node.js HTTP server to `build/index.js`, which `node build` executes.

## Test plan

- [ ] Railway deployment succeeds without "No start command was found" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)