### PR TITLE
feat(setup): add Stow tool to development setup

### DIFF
--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -28,6 +28,13 @@
 			link: 'https://brew.sh/'
 		},
 		{
+			name: 'Stow',
+			description:
+				'GNU Stow is a symlink farm manager. Perfect for managing dotfiles and configuration files across multiple tools and projects.',
+			installCommand: 'brew install stow',
+			link: 'https://formulae.brew.sh/formula/stow'
+		},
+		{
 			name: 'Doppler CLI',
 			description:
 				'Secure secret management for developers. Inject environment variables and sync secrets across your team and environments.',


### PR DESCRIPTION
## Summary

Added GNU Stow to the development tools list on the setup page. Stow is a symlink farm manager that helps developers manage dotfiles and configuration files across multiple tools and projects.

## Changes

- Add Stow to the tools array with installation instructions
- Include link to Homebrew formula page for reference
- Position Stow after Homebrew in the tools list

## Test plan

- [ ] Verify Stow displays correctly on the setup page
- [ ] Check that the installation command is copyable
- [ ] Verify the documentation link works
- [ ] Test on mobile to ensure responsive layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)