### PR TITLE
Add SDKMAN and Starship to setup tools list

### DIFF
--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -117,6 +117,25 @@
 			installCommand: 'brew install atuin',
 			link: 'https://atuin.sh/',
 			tags: ['cli', 'productivity']
+		},
+		{
+			name: 'SDKMAN',
+			description:
+				'The Software Development Kit Manager. Easily install, switch between, and manage multiple versions of SDKs like Java, Kotlin, Scala, and more.',
+			installSteps: [
+				{ label: 'Add SDKMAN tap', command: 'brew tap sdkman/tap' },
+				{ label: 'Install SDKMAN CLI', command: 'brew install sdkman-cli' }
+			],
+			link: 'https://github.com/sdkman/homebrew-tap',
+			tags: ['cli', 'development', 'package-manager']
+		},
+		{
+			name: 'Starship',
+			description:
+				'The minimal, blazing-fast, and infinitely customizable prompt for any shell. Written in Rust for speed and efficiency.',
+			installCommand: 'brew install starship',
+			link: 'https://starship.rs/',
+			tags: ['cli', 'productivity']
 		}
 	];
 


### PR DESCRIPTION
## Summary
Added two new developer tools to the setup page's available tools list: SDKMAN and Starship.

## Changes
- **SDKMAN**: A Software Development Kit Manager for easily installing and managing multiple versions of SDKs (Java, Kotlin, Scala, etc.)
  - Includes two-step installation via Homebrew tap
  - Tagged as: cli, development, package-manager
  
- **Starship**: A minimal, fast, and customizable shell prompt written in Rust
  - Single-command Homebrew installation
  - Tagged as: cli, productivity

## Implementation Details
Both tools follow the existing pattern in the setup tools array:
- SDKMAN uses `installSteps` for multi-step installation
- Starship uses `installCommand` for single-step installation
- Both include descriptive text, relevant tags, and links to official resources

https://claude.ai/code/session_016zrhyEcrTxeKeq4UBq5Ms6